### PR TITLE
Connect once to APNS and send all pushmessages over that connection

### DIFF
--- a/Service/OS/iOSNotification.php
+++ b/Service/OS/iOSNotification.php
@@ -131,7 +131,7 @@ class iOSNotification implements OSNotificationServiceInterface
     {
         // Get the correct Apn stream and send data
         $fp = $this->getApnStream($apnURL);
-        $response = ($length === @fwrite($fp, $payload, strlen($payload)));
+        $response = (strlen($payload) === @fwrite($fp, $payload, strlen($payload)));
 
         // Check if there is responsedata to read
         $readStreams = array($fp);


### PR DESCRIPTION
This fixes issue #13.
- Added some methods to manage the streams
- Supports switching from and to sandbox between messages (not of much use now, but it's future proof)
- Reconnects when connection is lost
- No changes in the class interface
- Major performance win. A very simple and not so scientific test when pushing 70 messages to APNS:
  Before: 32.9 seconds
  After: 1.1 seconds
