### PR TITLE
Decouple symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,13 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/symfony": "2.*",
         "kriswallsmith/buzz": "*"
+    },
+    "require-dev": {
+        "symfony/symfony": "2.*"
+    },
+    "suggest": {
+        "symfony/symfony": "To use as a bundle"
     },
     "autoload": {
         "psr-0": { "RMS\\PushNotificationsBundle": "" }


### PR DESCRIPTION
A start on #22, at least this way people can use the basics without pulling down all of symfony