### PR TITLE
Allowing injecting a client to AndroidGCMNotification

### DIFF
--- a/Service/OS/AndroidGCMNotification.php
+++ b/Service/OS/AndroidGCMNotification.php
@@ -49,11 +49,12 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
      * Constructor
      *
      * @param $apiKey
+     * @param MultiCurl $client (optional)
      */
-    public function __construct($apiKey)
+    public function __construct($apiKey, MultiCurl $client = null)
     {
         $this->apiKey = $apiKey;
-        $this->browser = new Browser(new MultiCurl());
+        $this->browser = new Browser($client ?: new MultiCurl());
     }
 
     /**


### PR DESCRIPTION
I've been having problems with GCM timeouts, this allows me to configure a
client with a reasonable timeout and inject it
