### PR TITLE
stream_select fires warning

### DIFF
--- a/Service/OS/iOSNotification.php
+++ b/Service/OS/iOSNotification.php
@@ -155,7 +155,7 @@ class iOSNotification implements OSNotificationServiceInterface
         // Check if there is responsedata to read
         $readStreams = array($fp);
         $null = NULL;
-        $streamsReadyToRead = stream_select($readStreams, $null, $null, 1, 0);
+        $streamsReadyToRead = @stream_select($readStreams, $null, $null, 1, 0);
         if ($streamsReadyToRead > 0) {
             // Unpack error response data and set as the result
             $response = @unpack("Ccommand/Cstatus/Nidentifier", fread($fp, 6));


### PR DESCRIPTION
stream_select fires a warning, but works fine. symfony2 stops working after that warning. i just disabled the printing. i got this error on windows only.

Warning: Invalid CRT parameters detected in [...] iOSNotification.php line 159 
