### PR TITLE
Test for existence of info method before calling it

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,14 +90,18 @@ class Configuration implements ConfigurationInterface
      */
     private function addApple($os)
     {
-        $this->root->
+        $config = $this->root->
             children()->
                 arrayNode($os)->
                     children()->
                         booleanNode("sandbox")->defaultFalse()->end()->
                         scalarNode("pem")->isRequired()->cannotBeEmpty()->end()->
                         scalarNode("passphrase")->defaultValue("")->end()->
-                        scalarNode('json_unescaped_unicode')->defaultFalse()->info('PHP >= 5.4.0 and each messaged must be UTF-8 encoding')->end()->
+                        scalarNode('json_unescaped_unicode')->defaultFalse();
+                        if (method_exists($config,'info')) {
+                            $config = $config->info('PHP >= 5.4.0 and each messaged must be UTF-8 encoding');
+                        }
+                        $config->end()->
                     end()->
                 end()->
             end()


### PR DESCRIPTION
We get the benefits of 2.1 but retain compatibility with 2.0 - no need to maintain a separate 2.0 branch.
