### PR TITLE
Badge numbers need to be an integer, not a string

### DIFF
--- a/Message/AppleMessage.php
+++ b/Message/AppleMessage.php
@@ -170,11 +170,11 @@ class AppleMessage implements MessageInterface
      * iOS-specific
      * Sets the APS badge count
      *
-     * @param string $badge The badge count to display
+     * @param integer $badge The badge count to display
      */
     public function setAPSBadge($badge)
     {
-        $this->apsBody["aps"]["badge"] = $badge;
+        $this->apsBody["aps"]["badge"] = (int) $badge;
     }
 
     /**


### PR DESCRIPTION
When they are sent as a string, it doesn't work - apple seems to just ignore the value.
