### PR TITLE
Optimizing  notification request performance 

### DIFF
--- a/Service/OS/AndroidGCMNotification.php
+++ b/Service/OS/AndroidGCMNotification.php
@@ -49,11 +49,12 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
      * Constructor
      *
      * @param $apiKey
+     * @param MultiCurl $client (optional)
      */
-    public function __construct($apiKey)
+    public function __construct($apiKey, MultiCurl $client = null)
     {
         $this->apiKey = $apiKey;
-        $this->browser = new Browser(new MultiCurl());
+        $this->browser = new Browser($client ?: new MultiCurl());
     }
 
     /**


### PR DESCRIPTION
In case of a large number of user, no need to check in every insert operation  if the device idenfiers array has duplicates entries because it causes memory issue.
Just check it only when we try to retrieve the list of identifier
  public function getGCMIdentifiers()
    {
        return array_unique($this->allIdentifiers);
    }
