### PR TITLE
Updated iOS Service for sending log-arcs without JSON_FORCE_OBJECT

### DIFF
--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -278,9 +278,9 @@ class AppleNotification implements OSNotificationServiceInterface
                 ));
             }
 
-            $jsonBody = json_encode($message, JSON_UNESCAPED_UNICODE ^ JSON_FORCE_OBJECT);
+            $jsonBody = json_encode($message, JSON_UNESCAPED_UNICODE);
         } else {
-            $jsonBody = json_encode($message, JSON_FORCE_OBJECT);
+            $jsonBody = json_encode($message);
         }
 
         $token = preg_replace("/[^0-9A-Fa-f]/", "", $token);


### PR DESCRIPTION
This is the same request as https://github.com/richsage/RMSPushNotificationsBundle/pull/40

Change still needs to be made. Please merge with your codebase.

Thanks,
