### PR TITLE
Configure timeout

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -135,7 +135,11 @@ class Configuration implements ConfigurationInterface
     {
         $this->root->
             children()->
-                booleanNode('windowsphone')->defaultFalse()->end()->
+                arrayNode('windowsphone')->
+                    children()->
+                        scalarNode("timeout")->defaultValue(5)->end()->
+                    end()->
+                end()->
             end()
         ;
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -121,6 +121,7 @@ class Configuration implements ConfigurationInterface
             children()->
                 arrayNode("blackberry")->
                     children()->
+                        scalarNode("timeout")->defaultValue(5)->end()->
                         booleanNode("evaluation")->defaultFalse()->end()->
                         scalarNode("app_id")->isRequired()->cannotBeEmpty()->end()->
                         scalarNode("password")->isRequired()->cannotBeEmpty()->end()->

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -98,6 +98,7 @@ class Configuration implements ConfigurationInterface
             children()->
                 arrayNode($os)->
                     children()->
+                        scalarNode("timeout")->defaultValue(60)->end()->
                         booleanNode("sandbox")->defaultFalse()->end()->
                         scalarNode("pem")->isRequired()->cannotBeEmpty()->end()->
                         scalarNode("passphrase")->defaultValue("")->end()->

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -132,6 +132,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * Windows Phone configuration
+     */
     protected function addWindowsphone()
     {
         $this->root->

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,8 @@ class Configuration implements ConfigurationInterface
                     canBeUnset()->
                     children()->
 
+                        scalarNode("timeout")->defaultValue(5)->end()->
+
                         // WARNING: These 3 fields as they are, outside of the c2dm array
                         // are deprecrated in favour of using the c2dm array configuration
                         // At present these will be overriden by anything supplied

--- a/DependencyInjection/RMSPushNotificationsExtension.php
+++ b/DependencyInjection/RMSPushNotificationsExtension.php
@@ -84,11 +84,13 @@ class RMSPushNotificationsExtension extends Extension
         $username = $config["android"]["username"];
         $password = $config["android"]["password"];
         $source = $config["android"]["source"];
+        $timeout = $config["android"]["timeout"];
         if (isset($config["android"]["c2dm"])) {
             $username = $config["android"]["c2dm"]["username"];
             $password = $config["android"]["c2dm"]["password"];
             $source = $config["android"]["c2dm"]["source"];
         }
+        $this->container->setParameter("rms_push_notifications.android.timeout", $timeout);
         $this->container->setParameter("rms_push_notifications.android.c2dm.username", $username);
         $this->container->setParameter("rms_push_notifications.android.c2dm.password", $password);
         $this->container->setParameter("rms_push_notifications.android.c2dm.source", $source);
@@ -160,6 +162,7 @@ class RMSPushNotificationsExtension extends Extension
         }
 
         $this->container->setParameter(sprintf('rms_push_notifications.%s.enabled', $os), true);
+        $this->container->setParameter(sprintf('rms_push_notifications.%s.timeout', $os), $config[$os]["timeout"]);
         $this->container->setParameter(sprintf('rms_push_notifications.%s.sandbox', $os), $config[$os]["sandbox"]);
         $this->container->setParameter(sprintf('rms_push_notifications.%s.pem', $os), $pemFile);
         $this->container->setParameter(sprintf('rms_push_notifications.%s.passphrase', $os), $config[$os]["passphrase"]);
@@ -174,6 +177,7 @@ class RMSPushNotificationsExtension extends Extension
     protected function setBlackberryConfig(array $config)
     {
         $this->container->setParameter("rms_push_notifications.blackberry.enabled", true);
+        $this->container->setParameter("rms_push_notifications.blackberry.timeout", $config["blackberry"]["timeout"]);
         $this->container->setParameter("rms_push_notifications.blackberry.evaluation", $config["blackberry"]["evaluation"]);
         $this->container->setParameter("rms_push_notifications.blackberry.app_id", $config["blackberry"]["app_id"]);
         $this->container->setParameter("rms_push_notifications.blackberry.password", $config["blackberry"]["password"]);
@@ -182,5 +186,6 @@ class RMSPushNotificationsExtension extends Extension
     protected function setWindowsphoneConfig(array $config)
     {
         $this->container->setParameter("rms_push_notifications.windowsphone.enabled", true);
+        $this->container->setParameter("rms_push_notifications.windowsphone.timeout", $config["windowsphone"]["timeout"]);
     }
 }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ only be available if you provide configuration respectively for them.
 
     rms_push_notifications:
       android:
+          timeout: 5 # Seconds to wait for connection timeout, default is 5
           c2dm:
               username: <string_android_c2dm_username>
               password: <string_android_c2dm_password>
@@ -43,20 +44,26 @@ only be available if you provide configuration respectively for them.
               api_key: <string_android_gcm_api_key> # This is titled "Server Key" when creating it
               use_multi_curl: <boolean_android_gcm_use_multi_curl> # default is true
       ios:
+          timeout: 60 # Seconds to wait for connection timeout, default is 60
           sandbox: <bool_use_apns_sandbox>
           pem: <path_apns_certificate> # can be absolute or relative path (from app directory)
           passphrase: <string_apns_certificate_passphrase>
       mac:
+          timeout: 60 # Seconds to wait for connection timeout, default is 60
           sandbox: <bool_use_apns_sandbox>
           pem: <path_apns_certificate>
           passphrase: <string_apns_certificate_passphrase>
       blackberry:
+          timeout: 5 # Seconds to wait for connection timeout, default is 5
           evaluation: <bool_bb_evaluation_mode>
           app_id: <string_bb_app_id>
           password: <string_bb_password>
-      windowsphone: true
+      windowsphone:
+          timeout: 5 # Seconds to wait for connection timeout, default is 5
 
 NOTE: If you are using Windows, you may need to set the Android GCM `use_multi_curl` flag to false for GCM messages to be sent correctly.
+
+Timeout defaults are the defaults from prior to the introduction of this configuration value.
 
 ## Usage
 

--- a/Resources/config/android.xml
+++ b/Resources/config/android.xml
@@ -15,6 +15,7 @@
             <argument>%rms_push_notifications.android.c2dm.username%</argument>
             <argument>%rms_push_notifications.android.c2dm.password%</argument>
             <argument>%rms_push_notifications.android.c2dm.source%</argument>
+            <argument>%rms_push_notifications.android.timeout%</argument>
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.android.c2dm" />
         </service>
 
@@ -22,6 +23,7 @@
         <service id="rms_push_notifications.android.gcm" class="%rms_push_notifications.android.gcm.class%" public="false">
             <argument>%rms_push_notifications.android.gcm.api_key%</argument>
             <argument>%rms_push_notifications.android.gcm.use_multi_curl%</argument>
+            <argument>%rms_push_notifications.android.timeout%</argument>
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.android.gcm" />
         </service>
 

--- a/Resources/config/blackberry.xml
+++ b/Resources/config/blackberry.xml
@@ -14,6 +14,7 @@
             <argument>%rms_push_notifications.blackberry.evaluation%</argument>
             <argument>%rms_push_notifications.blackberry.app_id%</argument>
             <argument>%rms_push_notifications.blackberry.password%</argument>
+            <argument>%rms_push_notifications.blackberry.timeout%</argument>
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.blackberry" />
         </service>
 

--- a/Resources/config/ios.xml
+++ b/Resources/config/ios.xml
@@ -15,6 +15,7 @@
             <argument>%rms_push_notifications.ios.pem%</argument>
             <argument>%rms_push_notifications.ios.passphrase%</argument>
             <argument>%rms_push_notifications.ios.json_unescaped_unicode%</argument>
+            <argument>%rms_push_notifications.ios.timeout%</argument>
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.ios" />
         </service>
 
@@ -23,6 +24,7 @@
             <argument>%rms_push_notifications.ios.sandbox%</argument>
             <argument>%rms_push_notifications.ios.pem%</argument>
             <argument>%rms_push_notifications.ios.passphrase%</argument>
+            <argument>%rms_push_notifications.ios.timeout%</argument>
         </service>
 
 

--- a/Resources/config/mac.xml
+++ b/Resources/config/mac.xml
@@ -15,6 +15,7 @@
             <argument>%rms_push_notifications.mac.pem%</argument>
             <argument>%rms_push_notifications.mac.passphrase%</argument>
             <argument>%rms_push_notifications.mac.json_unescaped_unicode%</argument>
+            <argument>%rms_push_notifications.mac.timeout%</argument>
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.mac" />
         </service>
     </services>

--- a/Resources/config/windowsphone.xml
+++ b/Resources/config/windowsphone.xml
@@ -11,6 +11,7 @@
 
         <!-- Windows Phone -->
         <service id="rms_push_notifications.windowsphone" class="%rms_push_notifications.windowsphone.class%" public="false">
+            <argument>%rms_push_notifications.windowsphone.timeout%</argument>
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.windowsphone" />
         </service>
 

--- a/Service/OS/AndroidGCMNotification.php
+++ b/Service/OS/AndroidGCMNotification.php
@@ -52,14 +52,17 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
      *
      * @param $apiKey
      * @param bool         $useMultiCurl
+     * @param int          $timeout
      * @param AbstractCurl $client       (optional)
      */
-    public function __construct($apiKey, $useMultiCurl, AbstractCurl $client = null)
+    public function __construct($apiKey, $useMultiCurl, $timeout, AbstractCurl $client = null)
     {
         $this->apiKey = $apiKey;
         if (!$client) {
             $client = ($useMultiCurl ? new MultiCurl() : new Curl());
         }
+        $client->setTimeout($timeout);
+
         $this->browser = new Browser($client);
         $this->browser->getClient()->setVerifyPeer(false);
     }

--- a/Service/OS/AndroidNotification.php
+++ b/Service/OS/AndroidNotification.php
@@ -32,6 +32,13 @@ class AndroidNotification implements OSNotificationServiceInterface
     protected $source;
 
     /**
+     * Timeout in seconds for the connecting client
+     *
+     * @var int
+     */
+    protected $timeout;
+
+    /**
      * Authentication token
      *
      * @var string
@@ -44,12 +51,14 @@ class AndroidNotification implements OSNotificationServiceInterface
      * @param $username
      * @param $password
      * @param $source
+     * @param $timeout
      */
-    public function __construct($username, $password, $source)
+    public function __construct($username, $password, $source, $timeout)
     {
         $this->username = $username;
         $this->password = $password;
         $this->source = $source;
+        $this->timeout = $timeout;
         $this->authToken = "";
     }
 
@@ -73,6 +82,7 @@ class AndroidNotification implements OSNotificationServiceInterface
 
             $buzz = new Browser();
             $buzz->getClient()->setVerifyPeer(false);
+            $buzz->getClient()->setTimeout($this->timeout);
             $response = $buzz->post("https://android.apis.google.com/c2dm/send", $headers, http_build_query($data));
 
             return preg_match("/^id=/", $response->getContent()) > 0;
@@ -98,6 +108,7 @@ class AndroidNotification implements OSNotificationServiceInterface
 
         $buzz = new Browser();
         $buzz->getClient()->setVerifyPeer(false);
+        $buzz->getClient()->setTimeout($this->timeout);
         $response = $buzz->post("https://www.google.com/accounts/ClientLogin", array(), http_build_query($data));
         if ($response->getStatusCode() !== 200) {
             return false;

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -58,6 +58,13 @@ class AppleNotification implements OSNotificationServiceInterface
     protected $jsonUnescapedUnicode = FALSE;
 
     /**
+     * Connection timeout
+     *
+     * @var int
+     */
+    protected $timeout;
+
+    /**
      * Collection of the responses from the APN
      *
      * @var array
@@ -71,7 +78,7 @@ class AppleNotification implements OSNotificationServiceInterface
      * @param $pem
      * @param $passphrase
      */
-    public function __construct($sandbox, $pem, $passphrase = "", $jsonUnescapedUnicode = FALSE)
+    public function __construct($sandbox, $pem, $passphrase = "", $jsonUnescapedUnicode = FALSE, $timeout = 60)
     {
         $this->useSandbox = $sandbox;
         $this->pem = $pem;
@@ -80,6 +87,7 @@ class AppleNotification implements OSNotificationServiceInterface
         $this->messages = array();
         $this->lastMessageId = -1;
         $this->jsonUnescapedUnicode = $jsonUnescapedUnicode;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -193,7 +201,7 @@ class AppleNotification implements OSNotificationServiceInterface
         if (!isset($this->apnStreams[$apnURL])) {
             // No stream found, setup a new stream
             $ctx = $this->getStreamContext();
-            $this->apnStreams[$apnURL] = stream_socket_client($apnURL, $err, $errstr, 60, STREAM_CLIENT_CONNECT, $ctx);
+            $this->apnStreams[$apnURL] = stream_socket_client($apnURL, $err, $errstr, $this->timeout, STREAM_CLIENT_CONNECT, $ctx);
             if (!$this->apnStreams[$apnURL]) {
                 throw new \RuntimeException("Couldn't connect to APN server. Error no $err: $errstr");
             }

--- a/Service/OS/BlackberryNotification.php
+++ b/Service/OS/BlackberryNotification.php
@@ -33,17 +33,26 @@ class BlackberryNotification implements OSNotificationServiceInterface
     protected $password;
 
     /**
+     * Timeout in seconds for the connecting client
+     *
+     * @var int
+     */
+    protected $timeout;
+
+    /**
      * Constructor
      *
      * @param $evaluation
      * @param $appID
      * @param $password
+     * @param $timeout
      */
-    public function __construct($evaluation, $appID, $password)
+    public function __construct($evaluation, $appID, $password, $timeout)
     {
         $this->evaluation = $evaluation;
         $this->appID = $appID;
         $this->password = $password;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -73,6 +82,7 @@ class BlackberryNotification implements OSNotificationServiceInterface
         $separator = "mPsbVQo0a68eIL3OAxnm";
         $body = $this->constructMessageBody($message, $separator);
         $browser = new Browser(new Curl());
+        $browser->getClient()->setTimeout($this->timeout);
         $listener = new BasicAuthListener($this->appID, $this->password);
         $browser->addListener($listener);
 

--- a/Service/OS/MicrosoftNotification.php
+++ b/Service/OS/MicrosoftNotification.php
@@ -17,10 +17,14 @@ class MicrosoftNotification implements OSNotificationServiceInterface
      */
     protected $browser;
 
-    public function __construct()
+    /**
+     * @param $timeout
+     */
+    public function __construct($timeout)
     {
         $this->browser = new Browser(new Curl());
         $this->browser->getClient()->setVerifyPeer(false);
+        $this->browser->getClient()->setTimeout($timeout);
     }
 
     public function send(MessageInterface $message)

--- a/Service/iOSFeedback.php
+++ b/Service/iOSFeedback.php
@@ -28,17 +28,26 @@ class iOSFeedback
     protected $passphrase;
 
     /**
+     * Connection timeout
+     *
+     * @var int
+     */
+    protected $timeout;
+
+    /**
      * Constructor
      *
      * @param $sandbox
      * @param $pem
      * @param $passphrase
+     * @param $timeout
      */
-    public function __construct($sandbox, $pem, $passphrase)
+    public function __construct($sandbox, $pem, $passphrase, $timeout)
     {
         $this->sandbox = $sandbox;
         $this->pem = $pem;
         $this->passphrase = $passphrase;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -61,7 +70,7 @@ class iOSFeedback
         $data = "";
 
         $ctx = $this->getStreamContext();
-        $fp = stream_socket_client($feedbackURL, $err, $errstr, 60, STREAM_CLIENT_CONNECT|STREAM_CLIENT_PERSISTENT, $ctx);
+        $fp = stream_socket_client($feedbackURL, $err, $errstr, $this->timeout, STREAM_CLIENT_CONNECT|STREAM_CLIENT_PERSISTENT, $ctx);
         if (!$fp) {
             throw new \RuntimeException("Couldn't connect to APNS Feedback service. Error no $err: $errstr");
         }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -59,6 +59,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
         $config = $this->process($arr);
         $this->assertArrayHasKey("android", $config);
+        $this->assertEquals(5, $config["android"]["timeout"]);
         $this->assertEquals("foo", $config["android"]["username"]);
         $this->assertEquals("bar", $config["android"]["password"]);
         $this->assertEquals("123", $config["android"]["source"]);
@@ -79,6 +80,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
         $config = $this->process($arr);
         $this->assertArrayHasKey("android", $config);
+        $this->assertEquals(5, $config["android"]["timeout"]);
         $this->assertArrayHasKey("c2dm", $config["android"]);
         $this->assertEquals("foo", $config["android"]["c2dm"]["username"]);
         $this->assertEquals("bar", $config["android"]["c2dm"]["password"]);
@@ -150,6 +152,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
         $config = $this->process($arr);
         $this->assertArrayHasKey("ios", $config);
+        $this->assertEquals(60, $config["ios"]["timeout"]);
         $this->assertEquals(false, $config["ios"]["sandbox"]);
         $this->assertEquals("foo/bar.pem", $config["ios"]["pem"]);
         $this->assertEquals("foo", $config["ios"]["passphrase"]);
@@ -188,6 +191,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
         $config = $this->process($arr);
         $this->assertArrayHasKey("mac", $config);
+        $this->assertEquals(60, $config["mac"]["timeout"]);
         $this->assertEquals(false, $config["mac"]["sandbox"]);
         $this->assertEquals("foo/bar.pem", $config["mac"]["pem"]);
         $this->assertEquals("foo", $config["mac"]["passphrase"]);
@@ -229,6 +233,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $config = $this->process($arr);
         $this->assertArrayHasKey("blackberry", $config);
         $this->assertFalse($config["blackberry"]["evaluation"]);
+        $this->assertEquals(5, $config["blackberry"]["timeout"]);
         $this->assertEquals("foo", $config["blackberry"]["app_id"]);
         $this->assertEquals("bar", $config["blackberry"]["password"]);
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -10,7 +10,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testDefaults()
     {
         $config = $this->process(array());
-        $this->assertArrayHasKey("windowsphone", $config);
     }
 
     /**
@@ -232,6 +231,31 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($config["blackberry"]["evaluation"]);
         $this->assertEquals("foo", $config["blackberry"]["app_id"]);
         $this->assertEquals("bar", $config["blackberry"]["password"]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testAddingWindowsKeyRequiresValues()
+    {
+        $arr = array(
+            array(
+                "windowsphone" => "~"
+            ),
+        );
+        $config = $this->process($arr);
+    }
+
+    public function testFullWindows()
+    {
+        $arr = array(
+            array(
+                "windowsphone" => array("timeout" => 5)
+            ),
+        );
+        $config = $this->process($arr);
+        $this->assertArrayHasKey("windowsphone", $config);
+        $this->assertEquals(5, $config["windowsphone"]["timeout"]);
     }
 
     /**


### PR DESCRIPTION
Fixes #80. Defaults are as before - 5 seconds for Android, Blackberry and Windows (since they use the Buzz client), and 60.

ping @andrewsmm @emiliomg - could you both test and see if this helps you?