### PR TITLE
Added ability to send MDM push notifications for Apple devices

### DIFF
--- a/Message/AppleMessage.php
+++ b/Message/AppleMessage.php
@@ -37,6 +37,27 @@ class AppleMessage implements MessageInterface
     protected $expiry = 0;
 
     /**
+     * Device push magic token
+     *
+     * @var string
+     */
+    protected $pushMagicToken = '';
+
+    /**
+     * Device token
+     *
+     * @var string
+     */
+    protected $token = '';
+
+    /**
+     * Whether this is a MDM message or not
+     *
+     * @var bool
+     */
+    protected $isMdmMessage = false;
+
+    /**
      * Class constructor
      */
     public function __construct($identifier = NULL)
@@ -207,5 +228,51 @@ class AppleMessage implements MessageInterface
     public function getExpiry()
     {
         return $this->expiry;
+    }
+
+    /**
+     * @param string $pushMagicToken
+     */
+    public function setPushMagicToken($pushMagicToken)
+    {
+        $this->pushMagicToken = $pushMagicToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPushMagicToken()
+    {
+        return $this->pushMagicToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * @param string $token
+     */
+    public function setToken($token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * @param null|bool $isMdmMessage
+     *
+     * @return bool|null
+     */
+    public function isMdmMessage($isMdmMessage = null)
+    {
+        if ($isMdmMessage === null) {
+            return $this->isMdmMessage;
+        }
+
+        $this->isMdmMessage = (bool) $isMdmMessage;
     }
 }

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -313,9 +313,6 @@ class AppleNotification implements OSNotificationServiceInterface
      */
     public function createMdmPayload($token, $magicPushToken)
     {
-        $token          = preg_replace("/[^0-9A-Fa-f]/", "", $token);
-        $magicPushToken = preg_replace("/[^0-9A-Fa-f]/", "", $magicPushToken);
-
         $jsonPayload = json_encode(array('mdm' => $magicPushToken));
 
         $payload = chr(0) . chr(0) . chr(32) . base64_decode($token) . chr(0)  . chr(strlen($jsonPayload)) . $jsonPayload;

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -316,7 +316,9 @@ class AppleNotification implements OSNotificationServiceInterface
         $token          = preg_replace("/[^0-9A-Fa-f]/", "", $token);
         $magicPushToken = preg_replace("/[^0-9A-Fa-f]/", "", $magicPushToken);
 
-        $payload = chr(0) . chr(0) . chr(32) . base64_decode($token) . chr(0)  . chr(strlen($magicPushToken)) . json_encode(array('mdm' => $magicPushToken));
+        $jsonPayload = json_encode(array('mdm' => $magicPushToken));
+
+        $payload = chr(0) . chr(0) . chr(32) . base64_decode($token) . chr(0)  . chr(strlen($jsonPayload)) . $jsonPayload;
 
         return $payload;
     }


### PR DESCRIPTION
Apple devices (iOS and OSX) suport MDM (Mobile Device Management). This pull request allows RMSPushNotificationsBundle to create and send specially-crafted MDM push messages.