### PR TITLE
Ability to add all identifiers at once

### DIFF
--- a/Message/AndroidMessage.php
+++ b/Message/AndroidMessage.php
@@ -214,6 +214,13 @@ class AndroidMessage implements MessageInterface
     }
 
     /**
+     * Sets the GCM list
+     */
+    public function setAllIdentifiers($allIdentifiers) {
+        $this->allIdentifiers = $allIdentifiers;
+    }
+
+    /**
      * Sets GCM options
      * @param array $options
      */


### PR DESCRIPTION
When you want to add a lot of GCM Identifiers (for example 100 000). You can't just use the addGCMIdentifier function since that would be too slow. Sometimes the validation on that function is not necessary.