### PR TITLE
Multiple APNS certificates

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -100,7 +100,7 @@ class Configuration implements ConfigurationInterface
                     children()->
                         scalarNode("timeout")->defaultValue(60)->end()->
                         booleanNode("sandbox")->defaultFalse()->end()->
-                        scalarNode("pem")->isRequired()->cannotBeEmpty()->end()->
+                        scalarNode("pem")->cannotBeEmpty()->end()->
                         scalarNode("passphrase")->defaultValue("")->end()->
                         scalarNode('json_unescaped_unicode')->defaultFalse();
                         if (method_exists($config,'info')) {

--- a/DependencyInjection/RMSPushNotificationsExtension.php
+++ b/DependencyInjection/RMSPushNotificationsExtension.php
@@ -139,16 +139,19 @@ class RMSPushNotificationsExtension extends Extension
             throw new \RuntimeException(sprintf('This Apple OS "%s" is not supported', $os));
         }
 
-        // PEM file is required
-        if (realpath($config[$os]["pem"])) {
-            // Absolute path
-            $pemFile = $config[$os]["pem"];
-        } elseif (realpath($this->kernelRootDir.DIRECTORY_SEPARATOR.$config[$os]["pem"]) ) {
-            // Relative path
-            $pemFile = $this->kernelRootDir.DIRECTORY_SEPARATOR.$config[$os]["pem"];
-        } else {
-            // path isn't valid
-            throw new \RuntimeException(sprintf('Pem file "%s" not found.', $config[$os]["pem"]));
+        $pemFile = null;
+        if (isset($config[$os]["pem"])) {
+            // If PEM is set, it must be a real file
+            if (realpath($config[$os]["pem"])) {
+                // Absolute path
+                $pemFile = $config[$os]["pem"];
+            } elseif (realpath($this->kernelRootDir.DIRECTORY_SEPARATOR.$config[$os]["pem"]) ) {
+                // Relative path
+                $pemFile = $this->kernelRootDir.DIRECTORY_SEPARATOR.$config[$os]["pem"];
+            } else {
+                // path isn't valid
+                throw new \RuntimeException(sprintf('Pem file "%s" not found.', $config[$os]["pem"]));
+            }
         }
 
         if ($config[$os]['json_unescaped_unicode']) {

--- a/Resources/config/ios.xml
+++ b/Resources/config/ios.xml
@@ -16,6 +16,8 @@
             <argument>%rms_push_notifications.ios.passphrase%</argument>
             <argument>%rms_push_notifications.ios.json_unescaped_unicode%</argument>
             <argument>%rms_push_notifications.ios.timeout%</argument>
+            <argument>%kernel.cache_dir%</argument>
+            <argument type="service" id="rms_push_notifications.event_listener" />
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.ios" />
         </service>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <parameter key="rms_push_notifications.ios.class">RMS\PushNotificationsBundle\Service\OS\AppleNotification</parameter>
         <parameter key="rms_push_notifications.ios.feedback.class">RMS\PushNotificationsBundle\Service\iOSFeedback</parameter>
         <parameter key="rms_push_notifications.mac.class">RMS\PushNotificationsBundle\Service\OS\AppleNotification</parameter>
+        <parameter key="rms_push_notifications.event_listener.class">RMS\PushNotificationsBundle\Service\EventListener</parameter>
     </parameters>
 
     <services>
@@ -17,6 +18,9 @@
         <service id="rms_push_notifications" class="%rms_push_notifications.class%">
         </service>
 
+        <service id="rms_push_notifications.event_listener" class="%rms_push_notifications.event_listener.class%">
+            <tag name="kernel.event_listener" event="kernel.terminate" method="onKernelTerminate" />
+        </service>
     </services>
 
 </container>

--- a/Service/EventListener.php
+++ b/Service/EventListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace RMS\PushNotificationsBundle\Service;
+
+
+class EventListener {
+
+    /**
+     * @var EventListenerInterface[]
+     */
+    protected $listeners = [];
+
+    /**
+     * @param EventListenerInterface $listener
+     */
+    public function addListener (EventListenerInterface $listener) {
+        $this->listeners[] = $listener;
+    }
+
+    /**
+     * Call onKernelTerminate on every listener
+     */
+    public function onKernelTerminate () {
+        foreach ($this->listeners as $listener) {
+            $listener->onKernelTerminate();
+        }
+    }
+}

--- a/Service/EventListenerInterface.php
+++ b/Service/EventListenerInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace RMS\PushNotificationsBundle\Service;
+
+
+interface EventListenerInterface {
+
+    public function onKernelTerminate ();
+}

--- a/Service/Notifications.php
+++ b/Service/Notifications.php
@@ -86,17 +86,17 @@ class Notifications
 
 
     /**
-     * Set Apple Push Notification Service certificate.
-     * Service won't use pem file passed by config.
+     * Set Apple Push Notification Service pem as string.
+     * Service won't use pem file passed by config anymore.
      *
-     * @param $certificate string
+     * @param $pemContent string
      * @param $passphrase
      */
-    public function setAPNSCertificateAsString($certificate, $passphrase) {
+    public function setAPNSPemAsString($pemContent, $passphrase) {
         if (isset($this->handlers[Types::OS_IOS]) && $this->handlers[Types::OS_IOS] instanceof AppleNotification) {
-            /** @var AppleNotification $APNS */
-            $APNS = $this->handlers[Types::OS_IOS];
-            $APNS->setCertificateAsString($certificate, $passphrase);
+            /** @var AppleNotification $appleNotification */
+            $appleNotification = $this->handlers[Types::OS_IOS];
+            $appleNotification->setPemAsString($pemContent, $passphrase);
         }
     }
 }

--- a/Service/Notifications.php
+++ b/Service/Notifications.php
@@ -2,7 +2,9 @@
 
 namespace RMS\PushNotificationsBundle\Service;
 
+use RMS\PushNotificationsBundle\Device\Types;
 use RMS\PushNotificationsBundle\Message\MessageInterface;
+use RMS\PushNotificationsBundle\Service\OS\AppleNotification;
 
 class Notifications
 {
@@ -80,5 +82,21 @@ class Notifications
     public function supports($targetOS)
     {
         return isset($this->handlers[$targetOS]);
+    }
+
+
+    /**
+     * Set Apple Push Notification Service certificate.
+     * Service won't use pem file passed by config.
+     *
+     * @param $certificate string
+     * @param $passphrase
+     */
+    public function setAPNSCertificateAsString($certificate, $passphrase) {
+        if (isset($this->handlers[Types::OS_IOS]) && $this->handlers[Types::OS_IOS] instanceof AppleNotification) {
+            /** @var AppleNotification $APNS */
+            $APNS = $this->handlers[Types::OS_IOS];
+            $APNS->setCertificateAsString($certificate, $passphrase);
+        }
     }
 }

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -410,5 +410,11 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
         if ($fs->exists(dirname($filename))) {
             $fs->remove(dirname($filename));
         }
+
+        // Close streams
+        foreach ($this->apnStreams as $stream) {
+            fclose($stream);
+        }
+
     }
 }

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -112,7 +112,7 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
      * @param string $cachedir
      * @param EventListener $eventListener
      */
-    public function __construct($sandbox, $pem, $passphrase = "", $jsonUnescapedUnicode = FALSE, $timeout = 60, $cachedir = "", EventListener $eventListener)
+    public function __construct($sandbox, $pem, $passphrase = "", $jsonUnescapedUnicode = FALSE, $timeout = 60, $cachedir = "", EventListener $eventListener = null)
     {
         $this->useSandbox = $sandbox;
         $this->pemPath = $pem;
@@ -124,7 +124,8 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
         $this->timeout = $timeout;
         $this->cachedir = $cachedir;
 
-        $eventListener->addListener($this);
+        if ($eventListener != null)
+            $eventListener->addListener($this);
     }
 
     /**

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -293,7 +293,7 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
         $pem = $this->pemPath;
         $passphrase = $this->passphrase;
 
-        // Create cache pem file
+        // Create cache pem file if needed
         if (!empty($this->pemContent)) {
             $filename = $this->cachedir . self::APNS_CERTIFICATE_FILE;
 
@@ -301,7 +301,7 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
             $fs->mkdir(dirname($filename));
             file_put_contents($filename, $this->pemContent);
 
-            // We now use this file as certificate
+            // Now we use this file as pem
             $pem = $filename;
             $passphrase = $this->pemContentPassphrase;
         }
@@ -391,16 +391,16 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
     }
 
     /**
-     * @param $certificate
+     * @param $pemContent
      * @param $passphrase
      */
-    public function setCertificateAsString($certificate, $passphrase) {
-        $this->pemContent = $certificate;
+    public function setPemAsString($pemContent, $passphrase) {
+        $this->pemContent = $pemContent;
         $this->pemContentPassphrase = $passphrase;
     }
 
     /**
-     * Call on kernel terminate
+     * Called on kernel terminate
      */
     public function onKernelTerminate() {
 


### PR DESCRIPTION
You can now use `rmsPushNotificator->setAPNSPemAsString($pemContent, $passphrase)` method to specify another certificate for Apple Push Notifications Service. It won't use pem specified in configuration anymore if you call this method.

`AppleNotification` class will write a pem file into cache and remove it on kernel terminate. It will be used by `stream_context_set_option` to set stream `local_cert` option.

Note that `onKernelTerminate` method into `AppleNotification` will also close all streams.