### PR TITLE
Logger for Android GCM

### DIFF
--- a/Resources/config/android.xml
+++ b/Resources/config/android.xml
@@ -24,6 +24,7 @@
             <argument>%rms_push_notifications.android.gcm.api_key%</argument>
             <argument>%rms_push_notifications.android.gcm.use_multi_curl%</argument>
             <argument>%rms_push_notifications.android.timeout%</argument>
+            <argument type="service" id="logger" />
             <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.android.gcm" />
         </service>
 

--- a/Service/OS/AndroidGCMNotification.php
+++ b/Service/OS/AndroidGCMNotification.php
@@ -48,14 +48,22 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
     protected $responses;
 
     /**
+     * Monolog logger
+     *
+     * @var Symfony\Bridge\Monolog\Logger
+     */
+    protected $logger;
+
+    /**
      * Constructor
      *
      * @param $apiKey
      * @param bool         $useMultiCurl
      * @param int          $timeout
+     * @param Logger       $logger
      * @param AbstractCurl $client       (optional)
      */
-    public function __construct($apiKey, $useMultiCurl, $timeout, AbstractCurl $client = null)
+    public function __construct($apiKey, $useMultiCurl, $timeout, $logger, AbstractCurl $client = null)
     {
         $this->apiKey = $apiKey;
         if (!$client) {
@@ -65,6 +73,7 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
 
         $this->browser = new Browser($client);
         $this->browser->getClient()->setVerifyPeer(false);
+        $this->logger = $logger;
     }
 
     /**
@@ -112,6 +121,11 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
         foreach ($this->responses as $response) {
             $message = json_decode($response->getContent());
             if ($message === null || $message->success == 0 || $message->failure > 0) {
+                if ($message == null) {
+                    $this->logger->err($response->getContent());
+                } else {
+                    $this->logger->err($message->failure);
+                }
                 return false;
             }
         }


### PR DESCRIPTION
At the moment the send method return only false or true which makes impossible to debug eventual issues.

I have added a basic logger for Android GCM errors.