### PR TITLE
Close apn stream in case of shutdown error

### DIFF
--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -102,6 +102,11 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
     const APNS_CERTIFICATE_FILE = '/rms_push_notifications/apns.pem';
 
     /**
+     * Status code retrieve when APNS server closed the connection
+     */
+    const APNS_SHUTDOWN_CODE = 10;
+
+    /**
      * Constructor
      *
      * @param $sandbox
@@ -203,7 +208,7 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
             if (is_array($result)) {
 
                 // Close the apn stream in case of Shutdown status code.
-                if ($result['status'] === 10) {
+                if ($result['status'] === self::APNS_SHUTDOWN_CODE) {
                     $this->closeApnStream($apnURL);
                 }
 

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -201,6 +201,12 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
 
             // Check if there is an error result
             if (is_array($result)) {
+
+                // Close the apn stream in case of Shutdown status code.
+                if ($result['status'] === 10) {
+                    $this->closeApnStream($apnURL);
+                }
+
                 $this->responses[] = $result;
                 // Resend all messages that were sent after the failed message
                 $this->sendMessages($result['identifier']+1, $apnURL);


### PR DESCRIPTION
According to the documentation : https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4

When the apns return a shutdown status code, the stream should be closed and create a new one.