### PR TITLE
Log the actual GCM error messages

### DIFF
--- a/Service/OS/AndroidGCMNotification.php
+++ b/Service/OS/AndroidGCMNotification.php
@@ -124,7 +124,11 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
                 if ($message == null) {
                     $this->logger->err($response->getContent());
                 } else {
-                    $this->logger->err($message->failure);
+                    foreach ($message->results as $result) {
+                        if (isset($result->error)) {
+                            $this->logger->error($result->error);
+                        }
+                    }
                 }
                 return false;
             }


### PR DESCRIPTION
Currently only the count of errors is logged, which is not very useful. This fix logs the actual error messages.