### PR TITLE
Add IOS notification category

### DIFF
--- a/Message/AppleMessage.php
+++ b/Message/AppleMessage.php
@@ -211,6 +211,17 @@ class AppleMessage implements MessageInterface
     }
 
     /**
+     * iOS-specific
+     * Sets the APS category
+     *
+     * @param string $category The notification category
+     */
+    public function setCategory($category)
+    {
+        $this->apsBody["aps"]["category"] = $category;
+    }
+
+    /**
      * Set expiry of message
      *
      * @param int $expiry


### PR DESCRIPTION
With IOS 8, Apple added a category option to handle custom actions in notifications :
https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/IPhoneOSClientImp.html#//apple_ref/doc/uid/TP40008194-CH103-SW1

This pull request allows to set this category option.