### PR TITLE
Assign the count of messages to a variable.

### DIFF
--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -208,7 +208,8 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
     {
         $errors = array();
         // Loop through all messages starting from the given ID
-        for ($currentMessageId = $firstMessageId; $currentMessageId < count($this->messages); $currentMessageId++) {
+        $messagesCount = count($this->messages);
+        for ($currentMessageId = $firstMessageId; $currentMessageId < $messagesCount; $currentMessageId++) {
             // Send the message
             $result = $this->writeApnStream($apnURL, $this->messages[$currentMessageId]);
 


### PR DESCRIPTION
count() in a for() loop condition is always a bad idea because the count() will always be executed, even if the $messages array does not change.