### PR TITLE
Standardise on PSR logger interface

### DIFF
--- a/Service/OS/AndroidGCMNotification.php
+++ b/Service/OS/AndroidGCMNotification.php
@@ -2,6 +2,7 @@
 
 namespace RMS\PushNotificationsBundle\Service\OS;
 
+use Psr\Log\LoggerInterface;
 use RMS\PushNotificationsBundle\Exception\InvalidMessageTypeException,
     RMS\PushNotificationsBundle\Message\AndroidMessage,
     RMS\PushNotificationsBundle\Message\MessageInterface;
@@ -58,7 +59,7 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
     /**
      * Monolog logger
      *
-     * @var Symfony\Bridge\Monolog\Logger
+     * @var LoggerInterface
      */
     protected $logger;
 
@@ -68,7 +69,7 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
      * @param string       $apiKey
      * @param bool         $useMultiCurl
      * @param int          $timeout
-     * @param Logger       $logger
+     * @param LoggerInterface $logger
      * @param AbstractCurl $client (optional)
      * @param bool         $dryRun
      */
@@ -136,7 +137,7 @@ class AndroidGCMNotification implements OSNotificationServiceInterface
             $message = json_decode($response->getContent());
             if ($message === null || $message->success == 0 || $message->failure > 0) {
                 if ($message == null) {
-                    $this->logger->err($response->getContent());
+                    $this->logger->error($response->getContent());
                 } else {
                     foreach ($message->results as $result) {
                         if (isset($result->error)) {

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -2,6 +2,7 @@
 
 namespace RMS\PushNotificationsBundle\Service\OS;
 
+use Psr\Log\LoggerInterface;
 use RMS\PushNotificationsBundle\Exception\InvalidMessageTypeException,
     RMS\PushNotificationsBundle\Message\AppleMessage,
     RMS\PushNotificationsBundle\Message\MessageInterface,
@@ -99,7 +100,7 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
     /**
      * Monolog logger
      *
-     * @var Symfony\Bridge\Monolog\Logger
+     * @var LoggerInterface
      */
     protected $logger;
 
@@ -123,7 +124,7 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
      * @param int           $timeout
      * @param string        $cachedir
      * @param EventListener $eventListener
-     * @param Logger        $logger
+     * @param LoggerInterface $logger
      */
     public function __construct($sandbox, $pem, $passphrase = "", $jsonUnescapedUnicode = FALSE, $timeout = 60, $cachedir = "", EventListener $eventListener = null, $logger = null)
     {
@@ -226,7 +227,7 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
                 $this->sendMessages($result['identifier']+1, $apnURL);
                 $errors[] = $result;
                 if ($this->logger) {
-                    $this->logger->err(json_encode($result));
+                    $this->logger->error(json_encode($result));
                 }
             } else {
                 $this->responses[] = true;

--- a/Service/OS/BlackberryNotification.php
+++ b/Service/OS/BlackberryNotification.php
@@ -2,6 +2,7 @@
 
 namespace RMS\PushNotificationsBundle\Service\OS;
 
+use Psr\Log\LoggerInterface;
 use RMS\PushNotificationsBundle\Exception\InvalidMessageTypeException,
     RMS\PushNotificationsBundle\Message\BlackberryMessage,
     RMS\PushNotificationsBundle\Message\MessageInterface;
@@ -42,7 +43,7 @@ class BlackberryNotification implements OSNotificationServiceInterface
     /**
      * Monolog logger
      *
-     * @var Symfony\Bridge\Monolog\Logger
+     * @var LoggerInterface
      */
     protected $logger;
 
@@ -154,12 +155,12 @@ class BlackberryNotification implements OSNotificationServiceInterface
         $doc->loadXML($response->getContent());
         $elems = $doc->getElementsByTagName("response-result");
         if (!$elems->length) {
-            $this->logger->err('Response is empty');
+            $this->logger->error('Response is empty');
             return false;
         }
         $responseElement = $elems->item(0);
         if ($responseElement->getAttribute("code") != "1001") {
-            $this->logger->err($responseElement->getAttribute("code"). ' : '. $responseElement->getAttribute("desc"));
+            $this->logger->error($responseElement->getAttribute("code"). ' : '. $responseElement->getAttribute("desc"));
         }
 
         return ($responseElement->getAttribute("code") == "1001");

--- a/Service/OS/MicrosoftNotification.php
+++ b/Service/OS/MicrosoftNotification.php
@@ -2,6 +2,7 @@
 
 namespace RMS\PushNotificationsBundle\Service\OS;
 
+use Psr\Log\LoggerInterface;
 use RMS\PushNotificationsBundle\Exception\InvalidMessageTypeException;
 use RMS\PushNotificationsBundle\Message\WindowsphoneMessage;
 use RMS\PushNotificationsBundle\Message\MessageInterface;
@@ -20,12 +21,13 @@ class MicrosoftNotification implements OSNotificationServiceInterface
     /**
      * Monolog logger
      *
-     * @var Symfony\Bridge\Monolog\Logger
+     * @var LoggerInterface
      */
     protected $logger;
 
     /**
      * @param $timeout
+     * @param $logger
      */
     public function __construct($timeout, $logger)
     {
@@ -60,7 +62,7 @@ class MicrosoftNotification implements OSNotificationServiceInterface
         $response = $this->browser->post($message->getDeviceIdentifier(), $headers, $xml->asXML());
 
         if (!$response->isSuccessful()) {
-            $this->logger->err($response->getStatusCode(). ' : '. $response->getReasonPhrase());
+            $this->logger->error($response->getStatusCode(). ' : '. $response->getReasonPhrase());
         }
 
         return $response->isSuccessful();

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "kriswallsmith/buzz": "*"
+        "kriswallsmith/buzz": "*",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "symfony/symfony": "2.*"


### PR DESCRIPTION
This removes the reliance/expectation on Monolog being the logger, and moves to using the PSR `LoggerInterface`. It then updates the relevant methods being called for error logging accordingly.