### PR TITLE
Close all APNS streams when setting PEM as string.

### DIFF
--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -461,6 +461,6 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
             fclose($stream);
         }
 
-        $this->apnStreams = [];
+        $this->apnStreams = array();
     }
 }

--- a/Service/OS/AppleNotification.php
+++ b/Service/OS/AppleNotification.php
@@ -420,6 +420,10 @@ class AppleNotification implements OSNotificationServiceInterface, EventListener
      * @param $passphrase
      */
     public function setPemAsString($pemContent, $passphrase) {
+        if ($this->pemContent === $pemContent && $this->pemContentPassphrase === $passphrase) {
+            return;
+        }
+
         $this->pemContent = $pemContent;
         $this->pemContentPassphrase = $passphrase;
 


### PR DESCRIPTION
When I have a set of notifications have to be sent to different iOS apps I need to set PEM as a string each time before sending push. In this case `AppleNotification` service uses the same stream because the **apn url** is not changing (https://github.com/richsage/RMSPushNotificationsBundle/blob/master/Service/OS/AppleNotification.php#L277 and https://github.com/richsage/RMSPushNotificationsBundle/blob/master/Service/OS/AppleNotification.php#L293). So a new pem was not used by `AppleNotification` after setting via `setPemAsString()`. Now it should.
