### PR TITLE
Windows uwp support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         $this->addMac();
         $this->addBlackberry();
         $this->addWindowsphone();
+        $this->addWindows();
 
         return $treeBuilder;
     }
@@ -143,6 +144,24 @@ class Configuration implements ConfigurationInterface
                 arrayNode('windowsphone')->
                     children()->
                         scalarNode("timeout")->defaultValue(5)->end()->
+                    end()->
+                end()->
+            end()
+        ;
+    }
+
+    /**
+     * Windows configuration
+     */
+    protected function addWindows()
+    {
+        $this->root->
+            children()->
+                arrayNode('windows')->
+                    children()->
+                        scalarNode("timeout")->defaultValue(5)->end()->
+                        scalarNode("sid")->isRequired()->cannotBeEmpty()->end()->
+                        scalarNode("secret")->isRequired()->cannotBeEmpty()->end()->
                     end()->
                 end()->
             end()

--- a/DependencyInjection/RMSPushNotificationsExtension.php
+++ b/DependencyInjection/RMSPushNotificationsExtension.php
@@ -58,6 +58,10 @@ class RMSPushNotificationsExtension extends Extension
             $this->setWindowsphoneConfig($config);
             $loader->load('windowsphone.xml');
         }
+        if (isset($config['windows'])) {
+            $this->setWindowsConfig($config);
+            $loader->load('windows.xml');
+        }
     }
 
     /**
@@ -191,5 +195,13 @@ class RMSPushNotificationsExtension extends Extension
     {
         $this->container->setParameter("rms_push_notifications.windowsphone.enabled", true);
         $this->container->setParameter("rms_push_notifications.windowsphone.timeout", $config["windowsphone"]["timeout"]);
+    }
+
+    protected function setWindowsConfig(array $config)
+    {
+        $this->container->setParameter("rms_push_notifications.windows.enabled", true);
+        $this->container->setParameter("rms_push_notifications.windows.timeout", $config["windows"]["timeout"]);
+        $this->container->setParameter("rms_push_notifications.windows.sid", $config["windows"]["sid"]);
+        $this->container->setParameter("rms_push_notifications.windows.secret", $config["windows"]["secret"]);
     }
 }

--- a/Device/Types.php
+++ b/Device/Types.php
@@ -11,4 +11,5 @@ class Types
     const OS_BLACKBERRY = "rms_push_notifications.os.blackberry";
     const OS_WINDOWSMOBILE = "rms_push_notifications.os.windowsmobile";
     const OS_WINDOWSPHONE = "rms_push_notifications.os.windowsphone";
+    const OS_WINDOWS = "rms_push_notifications.os.windows";
 }

--- a/Message/WindowsMessage.php
+++ b/Message/WindowsMessage.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace RMS\PushNotificationsBundle\Message;
+
+use RMS\PushNotificationsBundle\Device\Types;
+
+class WindowsMessage implements MessageInterface
+{
+    const TYPE_TOAST = 'wns/toast';
+    const TYPE_BADGE = 'wns/badge';
+    const TYPE_TILE = 'wns/tile';
+    const TYPE_RAW = 'wns/raw';
+
+    protected static $notificationClass = array(
+        self::TYPE_TOAST => 2
+    );
+
+    protected $identifier;
+
+    protected $text1 = '';
+
+    protected $text2 = '';
+
+    protected $type;
+
+    public function __construct()
+    {
+        $this->type = self::TYPE_TOAST;
+    }
+
+    public function getTargetOS()
+    {
+        return Types::OS_WINDOWS;
+    }
+
+    public function getDeviceIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    public function setDeviceIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getMessageBody()
+    {
+        return array(
+            'text1' => $this->text1,
+            'text2' => $this->text2
+        );
+    }
+
+    public function setMessage($message)
+    {
+        $this->text2 = $message;
+    }
+
+    public function setData($data)
+    {
+        // Not implemented yet
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getNotificationClass()
+    {
+        return static::$notificationClass[$this->getType()];
+    }
+}

--- a/Message/WindowsMessage.php
+++ b/Message/WindowsMessage.php
@@ -17,11 +17,14 @@ class WindowsMessage implements MessageInterface
 
     protected $identifier;
 
-    protected $text1 = '';
-
-    protected $text2 = '';
-
     protected $type;
+
+    protected $title;
+
+    protected $text;
+
+    protected $image;
+
 
     public function __construct()
     {
@@ -45,10 +48,7 @@ class WindowsMessage implements MessageInterface
 
     public function getMessageBody()
     {
-        return array(
-            'text1' => $this->text1,
-            'text2' => $this->text2
-        );
+        return $this->text;
     }
 
     public function setMessage($message)
@@ -64,6 +64,54 @@ class WindowsMessage implements MessageInterface
     public function getType()
     {
         return $this->type;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param mixed $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param mixed $text
+     */
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * @param mixed $image
+     */
+    public function setImage($image)
+    {
+        $this->image = $image;
     }
 
     public function getNotificationClass()

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ only be available if you provide configuration respectively for them.
           password: <string_bb_password>
       windowsphone:
           timeout: 5 # Seconds to wait for connection timeout, default is 5
+      windows:
+          timeout: 5 # Seconds to wait for connection timeout, default is 5
+          sid: # SID (Secure Identifier) as according to your app's entry in the windows dev center
+          secret: # Client secret according to your app's entry in the windows dev center
 
 NOTE: If you are using Windows, you may need to set the Android GCM `use_multi_curl` flag to false for GCM messages to be sent correctly.
 
@@ -115,6 +119,11 @@ Apple recommend you poll this service daily.
 ## Windows Phone - Toast support
 
 The bundle has beta support for Windows Phone, and supports the Toast notification. Use the `WindowsphoneMessage` message class to send accordingly.
+
+## Windows (Universal, WNS) - Toast support
+
+The bundle has beta support for Windows Notification Service (WNS), and supports the Toast notification. Use the `WindowsMessage` message class to send accordingly.
+
 
 # Thanks
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,7 @@
         <parameter key="rms_push_notifications.ios.feedback.class">RMS\PushNotificationsBundle\Service\iOSFeedback</parameter>
         <parameter key="rms_push_notifications.mac.class">RMS\PushNotificationsBundle\Service\OS\AppleNotification</parameter>
         <parameter key="rms_push_notifications.event_listener.class">RMS\PushNotificationsBundle\Service\EventListener</parameter>
+        <parameter key="rms_push_notifications.windows.class">RMS\PushNotificationsBundle\Service\OS\WindowsNotification</parameter>
     </parameters>
 
     <services>

--- a/Resources/config/windows.xml
+++ b/Resources/config/windows.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="rms_push_notifications.windows.class">RMS\PushNotificationsBundle\Service\OS\WindowsNotification</parameter>
+    </parameters>
+
+    <services>
+
+        <!-- Windows Universal WNS -->
+        <service id="rms_push_notifications.windows" class="%rms_push_notifications.windows.class%" public="false">
+            <argument>%rms_push_notifications.windows.sid%</argument>
+            <argument>%rms_push_notifications.windows.secret%</argument>
+            <argument>%rms_push_notifications.windows.timeout%</argument>
+            <argument>%kernel.cache_dir%</argument>
+            <argument type="service" id="rms_push_notifications.event_listener" />
+            <argument type="service" id="logger" />
+            <tag name="rms_push_notifications.handler" osType="rms_push_notifications.os.windows" />
+        </service>
+
+    </services>
+
+</container>

--- a/Service/OS/WindowsNotification.php
+++ b/Service/OS/WindowsNotification.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace RMS\PushNotificationsBundle\Service\OS;
+
+use Psr\Log\LoggerInterface;
+use RMS\PushNotificationsBundle\Exception\InvalidMessageTypeException;
+use RMS\PushNotificationsBundle\Message\WindowsMessage;
+use RMS\PushNotificationsBundle\Message\WindowsphoneMessage;
+use RMS\PushNotificationsBundle\Message\MessageInterface;
+use Buzz\Browser,
+    Buzz\Client\Curl;
+
+class WindowsNotification implements OSNotificationServiceInterface
+{
+    /**
+     * Browser object
+     *
+     * @var \Buzz\Browser
+     */
+    protected $browser;
+
+    /**
+     * Monolog logger
+     *
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * SID (Secure Identifier) as according to your app's entry in the windows dev center
+     *
+     * @var string
+     */
+    protected $sid;
+
+    /**
+     * Client secret according to your app's entry in the windows dev center
+     *
+     * @var string
+     */
+    protected $secret;
+
+    /**
+     * The system needs to request an oAuth access token to access WNS server. The token is requested once here and cached
+     * within one session.
+     *
+     * @var string
+     */
+    protected $accessToken;
+
+    /**
+     * @param $timeout
+     * @param $logger
+     */
+    public function __construct($sid, $secret, $timeout, $logger)
+    {
+        $this->browser = new Browser(new Curl());
+        $this->browser->getClient()->setVerifyPeer(false);
+        $this->browser->getClient()->setTimeout($timeout);
+        $this->logger = $logger;
+        $this->sid = $sid;
+        $this->secret = $secret;
+    }
+
+    protected function getAccessToken()
+    {
+        if ($this->accessToken != '') {
+            return;
+        }
+
+        $str = "grant_type=client_credentials&client_id=$this->sid&client_secret=$this->secret&scope=notify.windows.com";
+        $url = "https://login.live.com/accesstoken.srf";
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
+        curl_setopt($ch, CURLOPT_POSTFIELDS, "$str");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $output = curl_exec($ch);
+        curl_close($ch);
+        $output = json_decode($output);
+        if (isset($output->error)) {
+            throw new \Exception($output->error_description);
+        }
+        $this->accessToken = $output->access_token;
+    }
+
+    protected function buildTileXml($title, $img)
+    {
+        return '<?xml version="1.0" encoding="utf-16"?>' .
+        '<tile>' .
+        '<visual lang="en-US">' .
+        '<binding template="TileWideImageAndText01">' .
+        '<image id="1" src="' . $img . '"/>' .
+        '<text id="1">' . $title . '</text>' .
+        '</binding>' .
+        '</visual>' .
+        '</tile>';
+    }
+
+    public function send(MessageInterface $message)
+    {
+        if (!$message instanceof WindowsMessage) {
+            throw new InvalidMessageTypeException(sprintf("Message type '%s' not supported by WNS", get_class($message)));
+        }
+
+        if (!$this->accessToken) {
+            $this->getAccessToken();
+        }
+
+        $xml = $this->buildTileXml("test", "");
+
+        $headers = array('Content-Type: text/xml', "Content-Length: " . strlen($xml), "X-WNS-Type: $message->getType()", "Authorization: Bearer $this->accessToken");
+//        if ($tileTag != '') {
+//            array_push($headers, "X-WNS-Tag: $tileTag");
+//        }
+        $ch = curl_init($message->getDeviceIdentifier());
+        # Tiles: http://msdn.microsoft.com/en-us/library/windows/apps/xaml/hh868263.aspx
+        # http://msdn.microsoft.com/en-us/library/windows/apps/hh465435.aspx
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, "$xml");
+        curl_setopt($ch, CURLOPT_VERBOSE, 1);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $output = curl_exec($ch);
+        $response = curl_getinfo($ch);
+        curl_close($ch);
+
+        $code = $response['http_code'];
+        if ($code == 200) {
+            $this->logger->info("Message sent successfully");
+            return true;
+        } else if ($code == 401) {
+            $this->accessToken = '';
+            $this->logger->error($response->getStatusCode(). ' : '. $response->getReasonPhrase());
+            return false;
+        } else {
+            $this->logger->error($response->getStatusCode(). ' : '. $response->getReasonPhrase());
+            return false;
+        }
+
+    }
+}

--- a/Service/OS/WindowsNotification.php
+++ b/Service/OS/WindowsNotification.php
@@ -111,7 +111,7 @@ class WindowsNotification implements OSNotificationServiceInterface
 
         $xml = $this->buildTileXml("test", "");
 
-        $headers = array('Content-Type: text/xml', "Content-Length: " . strlen($xml), "X-WNS-Type: $message->getType()", "Authorization: Bearer $this->accessToken");
+        $headers = array('Content-Type: text/xml', "Content-Length: " . strlen($xml), "X-WNS-Type: " . $message->getType(), "Authorization: Bearer $this->accessToken");
 //        if ($tileTag != '') {
 //            array_push($headers, "X-WNS-Tag: $tileTag");
 //        }


### PR DESCRIPTION
I added very simple beta support for sending Windows WNS Messages. These are different from "Windows Phone" (8.0) and require oAuth authentication with the Microsoft server, so the existing Windowsphone class does not work for WNS push messages. 
I do not fully understand Microsoft's versioning strategy, but as far as I understand WNS is required for Windows 8.1 and Windows 10 whereas the existing classes worked for Windows Phone < 8.1
I called the classes just "Windows" as this seems to be the common name for Windows Universal (as opposed to "Windows phone" for < 8.1). I am happy for any feedback, e.g. if you prefer a different name for this or see a better way to extend the existing Microsoft classes.

WNS also supports four message types but I started with simply the "tile" message as this is the only one I need in the current project. 

Looking forward to your feedback.

Best
Felix