### PR TITLE
Added support for iOS push notifications title

### DIFF
--- a/Message/AppleMessage.php
+++ b/Message/AppleMessage.php
@@ -77,9 +77,9 @@ class AppleMessage implements MessageInterface
      *
      * @param $message
      */
-    public function setMessage($message)
+    public function setMessage($title, $message)
     {
-        $this->apsBody["aps"]["alert"] = $message;
+        $this->apsBody["aps"]["alert"] = array("title" => $title, "body" => $message);
     }
 
     /**


### PR DESCRIPTION
The title is displayed right below the app name in the notification in bold text and above the notification body.