### PR TITLE
Add 7.0 and 7.1 to travis PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: php
+
+before_install:
+  # If PHP >= 5.6, download & install PHPunit 5.7 to avoid builds failures
+  - if php -r "exit( (int)! version_compare( '$TRAVIS_PHP_VERSION', '5.6', '>=' ) );"; then wget -O phpunit https://phar.phpunit.de/phpunit-5.7.phar && chmod +x phpunit && mkdir ~/bin && mv -v phpunit ~/bin; fi
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 env:
   - SYMFONY_VERSION=origin/master
 


### PR DESCRIPTION
As all PHP versions from 5.3.0 are supported according to `composer.json`, test should also be run against `PHP 7.*`.